### PR TITLE
chore(ci): limit build and deploy job to mdn/todo-vue repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'mdn/todo-vue'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
There are some failing workflows on forks for the build and deploy step, limit these for future clones https://github.com/bsmth/todo-vue/actions/runs/4436727764