### PR TITLE
Fix base path

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,7 @@ export default defineConfig({
   plugins: [
     vue(),
   ],
+  base: 'https://mdn.github.io/todo-vue/',
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Added base path option in Vite config
https://vitejs.dev/config/shared-options.html#base

### Motivation

Currently it's a blank page https://mdn.github.io/todo-vue/. The error caused by wrong path for the assets:

- https://mdn.github.io/assets/index-BHtbZUUj.js
- https://mdn.github.io/assets/index-Br3MVAXe.css
- https://mdn.github.io/favicon.ico

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

—

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

—
