### PR TITLE
fix: call onCancel if label not changed while editing

### DIFF
--- a/src/components/ToDoItemEditForm.vue
+++ b/src/components/ToDoItemEditForm.vue
@@ -21,6 +21,7 @@
     </div>
   </form>
 </template>
+
 <script>
 export default {
   props: {
@@ -42,6 +43,8 @@ export default {
     onSubmit() {
       if (this.newLabel && this.newLabel !== this.label) {
         this.$emit("item-edited", this.newLabel);
+      } else {
+        this.onCancel();
       }
     },
     onCancel() {
@@ -54,6 +57,7 @@ export default {
   },
 };
 </script>
+
 <style scoped>
 .edit-label {
   font-family: Arial, sans-serif;


### PR DESCRIPTION

### Description

Editing a todo without changing the label value gets us into an unhandled state. Adding an `onCancel` to help with this.

### Related issues and pull requests

* Fixes #133