### PR TITLE
Revert "chore(deps-dev): bump eslint-plugin-vue from 9.27.0 to 9.28.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@vitejs/plugin-vue": "^5.1.3",
         "@vue/eslint-config-prettier": "^9.0.0",
         "eslint": "^8.57.0",
-        "eslint-plugin-vue": "^9.28.0",
+        "eslint-plugin-vue": "^9.27.0",
         "prettier": "^3.3.3",
         "vite": "^5.4.2"
       },
@@ -1283,9 +1283,9 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.28.0.tgz",
-      "integrity": "sha512-ShrihdjIhOTxs+MfWun6oJWuk+g/LAhN+CiuOl/jjkG3l0F2AuK5NMTaWqyvBgkFtpYmyks6P4603mLmhNJW8g==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.27.0.tgz",
+      "integrity": "sha512-5Dw3yxEyuBSXTzT5/Ge1X5kIkRTQ3nvBn/VwPwInNiZBSJOO/timWMUaflONnFBzU6NhB68lxnCda7ULV5N7LA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
@@ -1293,7 +1293,7 @@
         "natural-compare": "^1.4.0",
         "nth-check": "^2.1.1",
         "postcss-selector-parser": "^6.0.15",
-        "semver": "^7.6.3",
+        "semver": "^7.6.0",
         "vue-eslint-parser": "^9.4.3",
         "xml-name-validator": "^4.0.0"
       },
@@ -2100,9 +2100,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@vitejs/plugin-vue": "^5.1.3",
     "@vue/eslint-config-prettier": "^9.0.0",
     "eslint": "^8.57.0",
-    "eslint-plugin-vue": "^9.28.0",
+    "eslint-plugin-vue": "^9.27.0",
     "prettier": "^3.3.3",
     "vite": "^5.4.2"
   }


### PR DESCRIPTION
Reverts mdn/todo-vue#251