### PR TITLE
fix(workflows): disable cache in privileged workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
-          cache: "npm"
       - run: npm i
       - run: npm run build
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Disables the cache (used by `actions/setup-node`) in privileged workflows.

#### Test results and supporting details

This limits the impact of less-privileged workflows that may be vulnerable to code injection.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
