### PR TITLE
ci(CODEOWNERS): add content team for npm dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,5 +10,5 @@
 /.github/workflows/ @mdn/engineering
 /.github/CODEOWNERS @mdn/engineering
 /SECURITY.md        @mdn/engineering
-/package.json       @mdn/engineering @mdn-bot
-/package-lock.json  @mdn/engineering @mdn-bot
+/package.json       @mdn/content-team @mdn-bot
+/package-lock.json  @mdn/content-team @mdn-bot


### PR DESCRIPTION
### Description

Adds content team as code owner for npm dependencies, instead of engineering team.

### Motivation

Ensures the content team can update the example autonomously.

### Additional details

Cf. [this thread on todo-react PR](https://github.com/mdn/todo-react/pull/314#pullrequestreview-4146824213).

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
